### PR TITLE
Support for Block Matrices

### DIFF
--- a/Test/matrix_expression.cpp
+++ b/Test/matrix_expression.cpp
@@ -503,6 +503,220 @@ BOOST_AUTO_TEST_CASE( Remora_matrix_Binary_Min)
 }
 
 
+/////////////////////////////////////////////////////////////
+//////MATRIX CONCATENATION
+/////////////////////////////////////////////////////////////
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Matrix_Right)
+{
+	matrix<double> x(Dimension1, Dimension2); 
+	matrix<double> y(Dimension1,2 * Dimension2); 
+	matrix<double> result(Dimension1, 3 * Dimension2);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			y(i,j) = i+j+1;
+			y(i,j+Dimension2) = i+j+2;
+			result(i,j)= x(i,j);
+			result(i,j+Dimension2)= y(i,j);
+			result(i,j+2*Dimension2)= y(i,j+Dimension2);
+		}
+	}
+	matrix<double> test_assign = x|y;
+	matrix<double> test_plus_assign(Dimension1, 3 * Dimension2,1.0); 
+	noalias(test_plus_assign) += x|y;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Matrix_Bottom)
+{
+	matrix<double> x(Dimension1, Dimension2); 
+	matrix<double> y(2 * Dimension1,Dimension2); 
+	matrix<double> result(3 *Dimension1, Dimension2);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			y(i,j) = i+j+1;
+			y(i+Dimension1, j) = i+j+2;
+			result(i,j)= x(i,j);
+			result(i + Dimension1, j)= y(i,j);
+			result(i + 2 * Dimension1, j)= y(i + Dimension1,j);
+		}
+	}
+	matrix<double> test_assign = x & y;
+	matrix<double> test_plus_assign(3 * Dimension1, Dimension2,1.0); 
+	noalias(test_plus_assign) += x & y;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Vector_Right)
+{
+	matrix<double> x(Dimension1, Dimension2); 
+	vector<double> y(Dimension1); 
+	matrix<double> result(Dimension1, Dimension2+1);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i,j)= x(i,j);
+		}
+		y(i) = i;
+		result(i,Dimension2) = y(i);
+	}
+	matrix<double> test_assign = x|y;
+	matrix<double> test_plus_assign(Dimension1, Dimension2 +1 ,1.0); 
+	noalias(test_plus_assign) += x|y;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Vector_Left)
+{
+	matrix<double> x(Dimension1, Dimension2); 
+	vector<double> y(Dimension1); 
+	matrix<double> result(Dimension1, Dimension2+1);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i,j + 1)= x(i,j);
+		}
+		y(i) = i;
+		result(i,0) = y(i);
+	}
+	matrix<double> test_assign = y|x;
+	matrix<double> test_plus_assign(Dimension1, Dimension2 +1 ,1.0); 
+	noalias(test_plus_assign) += y|x;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Vector_Bottom)
+{
+	matrix<double> x(Dimension1, Dimension2); 
+	vector<double> y(Dimension2); 
+	matrix<double> result(Dimension1 + 1, Dimension2);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i,j)= x(i,j);
+		}
+	}
+	for (size_t i = 0; i < Dimension2; i++){
+		y(i) = i;
+		result(Dimension1,i) = y(i);
+	}
+	matrix<double> test_assign = x&y;
+	matrix<double> test_plus_assign(Dimension1 + 1, Dimension2 ,1.0); 
+	noalias(test_plus_assign) += x&y;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Vector_Top)
+{
+	matrix<double> x(Dimension1, Dimension2); 
+	vector<double> y(Dimension2); 
+	matrix<double> result(Dimension1 + 1, Dimension2);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i + 1,j)= x(i,j);
+		}
+	}
+	for (size_t i = 0; i < Dimension2; i++){
+		y(i) = i;
+		result(0,i) = y(i);
+	}
+	matrix<double> test_assign = y&x;
+	matrix<double> test_plus_assign(Dimension1 + 1, Dimension2 ,1.0); 
+	noalias(test_plus_assign) += y&x;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Scalar_Left){
+	matrix<double> x(Dimension1, Dimension2); 
+	double t = 2.0;
+	matrix<double> result(Dimension1, Dimension2 + 1);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i,j+1)= x(i,j);
+			result(i,0) = t;
+		}
+	}
+	matrix<double> test_assign = t | x;
+	matrix<double> test_plus_assign(Dimension1, Dimension2 + 1,1.0); 
+	noalias(test_plus_assign) += t | x;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Scalar_Right){
+	matrix<double> x(Dimension1, Dimension2); 
+	double t = 2.0;
+	matrix<double> result(Dimension1, Dimension2 + 1);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i,j)= x(i,j);
+			result(i,Dimension2) = t;
+		}
+	}
+	matrix<double> test_assign = x | t;
+	matrix<double> test_plus_assign(Dimension1, Dimension2 + 1,1.0); 
+	noalias(test_plus_assign) += x | t;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Scalar_Bottom){
+	matrix<double> x(Dimension1, Dimension2); 
+	double t = 2.0;
+	matrix<double> result(Dimension1 + 1, Dimension2);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i,j)= x(i,j);
+			result(Dimension1, j) = t;
+		}
+	}
+	matrix<double> test_assign = x & t;
+	matrix<double> test_plus_assign(Dimension1 + 1, Dimension2,1.0); 
+	noalias(test_plus_assign) += x & t;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+BOOST_AUTO_TEST_CASE( Remora_Concat_Matrix_Scalar_Top){
+	matrix<double> x(Dimension1, Dimension2); 
+	double t = 2.0;
+	matrix<double> result(Dimension1 + 1, Dimension2);
+	
+	for (size_t i = 0; i < Dimension1; i++){
+		for (size_t j = 0; j < Dimension2; j++){
+			x(i,j) = 50.0+i-j;
+			result(i + 1,j)= x(i,j);
+			result(0, j) = t;
+		}
+	}
+	matrix<double> test_assign = t & x;
+	matrix<double> test_plus_assign(Dimension1 + 1, Dimension2,1.0); 
+	noalias(test_plus_assign) += t & x;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
 ////////////////////////////////////////////////////////////////////////
 ////////////ROW-WISE REDUCTIONS
 ////////////////////////////////////////////////////////////////////////

--- a/Test/vector_expression.cpp
+++ b/Test/vector_expression.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE( Remora_Vector_Scalar_Concat )
 	}
 	vector<double> test_assign = x|alpha;
 	vector<double> test_plus_assign(Dimensions+1,1.0); 
-	test_plus_assign += x|alpha;
+	noalias(test_plus_assign) += x|alpha;
 	checkDenseExpressionEquality(test_assign,result);
 	checkDenseExpressionEquality(test_plus_assign,result+1.0);
 }
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE( Remora_Scalar_Vector_Concat )
 	}
 	vector<double> test_assign = alpha|x;
 	vector<double> test_plus_assign(Dimensions+1,1.0); 
-	test_plus_assign += alpha|x;
+	noalias(test_plus_assign) += alpha|x;
 	checkDenseExpressionEquality(test_assign,result);
 	checkDenseExpressionEquality(test_plus_assign,result+1.0);
 }
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE( Remora_Vector_Vector_Concat )
 	}
 	vector<double> test_assign = x|y;
 	vector<double> test_plus_assign(Dimensions * 2,1.0); 
-	test_plus_assign += x|y;
+	noalias(test_plus_assign) += x|y;
 	checkDenseExpressionEquality(test_assign,result);
 	checkDenseExpressionEquality(test_plus_assign,result+1.0);
 }

--- a/Test/vector_expression.cpp
+++ b/Test/vector_expression.cpp
@@ -261,6 +261,62 @@ BOOST_AUTO_TEST_CASE( Remora_Vector_Safe_Div )
 }
 
 /////////////////////////////////////////////////////
+///////////Vector Concatenation///////////
+/////////////////////////////////////////////////////
+BOOST_AUTO_TEST_CASE( Remora_Vector_Scalar_Concat )
+{
+	vector<double> x(Dimensions); 
+	double alpha = 2.0;
+	vector<double> result(Dimensions+1);
+	result(Dimensions) = alpha;
+	
+	for (size_t i = 0; i < Dimensions; i++){
+		x(i) = exp(-(i-5.0)*(i-5.0));
+		result(i) = x(i);
+	}
+	vector<double> test_assign = x|alpha;
+	vector<double> test_plus_assign(Dimensions+1,1.0); 
+	test_plus_assign += x|alpha;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+BOOST_AUTO_TEST_CASE( Remora_Scalar_Vector_Concat )
+{
+	vector<double> x(Dimensions); 
+	double alpha = 2.0;
+	vector<double> result(Dimensions+1);
+	result(0) = alpha;
+	
+	for (size_t i = 0; i < Dimensions; i++){
+		x(i) = exp(-(i-5.0)*(i-5.0));
+		result(i+1) = x(i);
+	}
+	vector<double> test_assign = alpha|x;
+	vector<double> test_plus_assign(Dimensions+1,1.0); 
+	test_plus_assign += alpha|x;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+BOOST_AUTO_TEST_CASE( Remora_Vector_Vector_Concat )
+{
+	vector<double> x(Dimensions); 
+	vector<double> y(Dimensions); 
+	vector<double> result(Dimensions * 2);
+	
+	for (size_t i = 0; i < Dimensions; i++){
+		x(i) = exp(-(i-5.0)*(i-5.0));
+		y(i) = exp(-(i-3.0)*(i-3.0));
+		result(i) = x(i);
+		result(i+Dimensions) = y(i);
+	}
+	vector<double> test_assign = x|y;
+	vector<double> test_plus_assign(Dimensions * 2,1.0); 
+	test_plus_assign += x|y;
+	checkDenseExpressionEquality(test_assign,result);
+	checkDenseExpressionEquality(test_plus_assign,result+1.0);
+}
+
+/////////////////////////////////////////////////////
 ///////////Vector Reductions///////////
 /////////////////////////////////////////////////////
 
@@ -340,7 +396,7 @@ BOOST_AUTO_TEST_CASE( Remora_Vector_norm_sqr )
 	double result = 0;
 	
 	for (size_t i = 0; i < Dimensions; i++){
-		x(i) = 2*i-5;
+		x(i) = 2.0*i-5;
 		result +=x(i)*x(i);
 	}
 	BOOST_CHECK_CLOSE(norm_sqr(x),result,1.e-10);
@@ -351,7 +407,7 @@ BOOST_AUTO_TEST_CASE( Remora_Vector_norm_2 )
 	double result = 0;
 	
 	for (size_t i = 0; i < Dimensions; i++){
-		x(i) = 2*i-5;
+		x(i) = 2.0*i-5;
 		result +=x(i)*x(i);
 	}
 	result = std::sqrt(result);
@@ -388,8 +444,6 @@ BOOST_AUTO_TEST_CASE( Remora_Vector_inner_prod )
 	}
 	BOOST_CHECK_CLOSE(inner_prod(x,y),(double)Dimensions,1.e-5);
 }
-
-
 
 //////////////////////////////SPARSE TESTS//////////////////////////////
 

--- a/doc/sphinx_pages/index.tut
+++ b/doc/sphinx_pages/index.tut
@@ -53,21 +53,22 @@ We first generate the data and label matrices for linear regression::
   ..includecode<linear_regression.tpp,data_declaration>
 
 We skip the step of data generation, but `X(i,j) = value;` and `y(i) = value;` do the trick.
-The formula for linear regression is :math:`w = (X^TX)^{-1}X^T y`. In a typical
+The formula for linear regression with bias is :math:`w = ((X|1)^T(X|1))^{-1}(X|1)^T y`. Here,
+(X|1) stands for the matrix X where a column of ones is added to the end. In a typical
 implementation we have to be careful, that the matrix has full rank and use a pseudo-inverse instead::
 
     ..includecode<linear_regression.tpp,solve_w>
 
-Operator ``%`` performs matrix-multiplication, ``trans(X)`` is matrix transposition
+Operator ``%`` performs matrix-multiplication, ``trans(A)`` is matrix transposition
 and ``inv(A,tag)`` performs matrix inversion where we have to supply information
 about how to invert that matrix.  Note that no actual matrix inversion is taking place.
 The system automatically detects that the matrix inverse is multiplied with another
 matrix and instead instructs to solve
-a system of equations with multiple right hand sides :math:`X^T`.
+a system of equations with multiple right hand sides :math:`(X|1)^T`.
 Likewise it detects the result is then multiplied with a vector from the right.
-This allows the transformation :math:`(X^TX) w = X^Ty` where we solve for :math:`w`.
+This allows the transformation :math:`((X|1)^T(X|1)) w = (X|1)^Ty` where we solve for :math:`w`.
 
-Finally, we compute goodness of fit using the formula :math:`E(w)=\frac 1 {2N} \sum_{i=1}^N (x_i^Tw -y)^2`::
+Finally, we compute goodness of fit using the formula :math:`E(w)=\frac 1 {2N} \sum_{i=1}^N ((x_i|1)^Tw -y)^2`::
 
   ..includecode<linear_regression.tpp,compute_error>
 

--- a/doc/sphinx_pages/quick_ref.rst
+++ b/doc/sphinx_pages/quick_ref.rst
@@ -168,6 +168,37 @@ Operation           			Effect
 ``outer_prod(x,y)``			outer product leading a matrix C with :math:`C_{ij}=x_i y_j`.
 ======================================= ==================================================================
 
+Block Matrix Operations
+*********************************************
+These matrix operation create larger matrices from smaller ones using operators ``&`` and ``|``.
+Asumme you have matrices A,B,C and D. And you want to create
+
+.. math::
+	C=
+		\left[
+			\begin{array}{c|c}
+				A & B \\
+				\hline
+				C & D
+			\end{array}
+		\right]
+
+This can easily be done using ``(A | B) & (C | D)``. The allowed
+operations are:
+
+======================================= ==================================================================
+Operation           			Effect
+======================================= ==================================================================
+``x | y``				Creates a vector of the values of x followed by values of y
+``A | B``				Block Matrix where B is right of A
+``A & B``				Block Matrix where B is below A
+``A | x, x | A``			Vector x is interpreted as matrix with one column
+``A & x, x & A``			Vector x is interpreted as matrix with one row
+``A | t, t | A, A & t, t & A``		Scalar t is interpreted as matrix with a single
+					row or column matching A. 
+					``(A|1)`` adds a column of all ones to the right
+======================================= ==================================================================
+
 
 Matrix and Vector Reductions
 *************************************************************************************

--- a/examples/linear_regression.tpp
+++ b/examples/linear_regression.tpp
@@ -9,14 +9,14 @@ using namespace remora;
 
 int main(){
 	//Step 0: Theory
-	// The goal of linear regression is to find a linear function f(x) = w^Tx
+	// The goal of linear regression is to find a linear function f(x) = w^Tx + b
 	// that fits best a given set of point-label pairs (x1,y1),(x2,y2),...,(xN,yN).
 	// This is measured by the squared error:
 	// E(w) = 1/(2N) sum_i (f(x_i)-y_i)^2
 	// It turns out that the optimal solution can be written in simple matrix algebra,
 	// when X is the data matrix where points are stored row-wise and y is the vector
 	// of labels:
-	// w=(X^TX)^{-1}X^Ty
+	// w=((X|1)^T (X|1))^{-1} (X|1)^Ty
 	
 	//Step 1: Generate some random data
 	//###begin<data_declaration>
@@ -39,28 +39,28 @@ int main(){
 	std::normal_distribution<> normal_noise(0,0.1);
 	for(std::size_t i = 0; i != num_data_points; ++i){
 		//label is chosen to be just the sum of entries plus some noise
-		y(i) = sum(row(X,i)) + normal_noise(gen);
+		y(i) = sum(row(X,i)) + normal_noise(gen) + 1;
 	}
 	//###end<generate_Y>
 	// Step 2: compute the linear regression
-	// formula is w=(X^TX)^{-1}X^Ty
+	// formula is w=((X|1)^T (X|1))^{-1} (X|1)^Ty
 	// we need to tell the algebra how to solve the system of equations,
 	// in this case we tell it that the matrix is symmetric positive definite.
 	// but we have to be aware that our matrix is not always full rank,
 	// e..g when we have more variables than data or when some variable
 	// is constant 0.
 	//###begin<solve_w>
-	vector<double> w = inv(trans(X) % X, symm_semi_pos_def()) % trans(X) % y; 
+	vector<double> w = inv(trans(X|1) % (X|1), symm_semi_pos_def()) % trans(X|1) % y; 
 	//###end<solve_w>
 	// Step 3: evaluate solution
 	// we compute: E(w) = 1/(2N) sum_i (f(x_i)-y_i)^2
 	//###begin<compute_error>
-	double error = 0.5 * sum(sqr(X % w - y))/num_data_points;
+	double error = 0.5 * sum(sqr((X|1) % w - y))/num_data_points;
 	//###end<compute_error>
 	// Step 4: For ensuring correctness, we will check that
 	// the derivative of E(w) at the solution is small (on the order of 1.e-14)
 	//###begin<verify_derivative>
-	vector<double> derE= trans(X) % (X % w - y) / num_data_points;
+	vector<double> derE= trans(X|1) % ((X|1) % w - y) / num_data_points;
 	double error_derivative = norm_inf(derE);
 	//###end<verify_derivative>
 	std::cout<<"final error of fit: "<< error<<std::endl;

--- a/include/remora/detail/expression_optimizers.hpp
+++ b/include/remora/detail/expression_optimizers.hpp
@@ -212,13 +212,26 @@ template<class M1, class M2>
 struct matrix_transpose_optimizer<matrix_matrix_prod<M1,M2> >{
 	typedef matrix_transpose_optimizer<typename const_expression<M2>::type> left_opt;
 	typedef matrix_transpose_optimizer<typename const_expression<M1>::type> right_opt;
-	typedef matrix_matrix_prod<typename left_opt::type,typename right_opt::type > type;
+	typedef matrix_matrix_prod_optimizer<typename left_opt::type,typename right_opt::type> opt;
+	typedef typename opt::type type;
 	
 	static type create(matrix_matrix_prod<M1,M2> const& m){
-		return type(left_opt::create(m.rhs()),right_opt::create(m.lhs()));
+		return opt::create(left_opt::create(m.rhs()),right_opt::create(m.lhs()));
 	}
 };
 
+//(A | B)^T= (A^T & B^T)
+//(A & B)^T= (A^T | B^T)
+template<class M1, class M2, bool B>
+struct matrix_transpose_optimizer<matrix_concat<M1,M2,B> >{
+	typedef matrix_transpose_optimizer<typename const_expression<M2>::type> right_opt;
+	typedef matrix_transpose_optimizer<typename const_expression<M1>::type> left_opt;
+	typedef matrix_concat<typename left_opt::type,typename right_opt::type,!B > type;
+	
+	static type create(matrix_concat<M1,M2,B> const& m){
+		return type(left_opt::create(m.lhs()),right_opt::create(m.rhs()));
+	}
+};
 
 ////////////////////////////////////
 //// Matrix Row

--- a/include/remora/detail/vector_expression_classes.hpp
+++ b/include/remora/detail/vector_expression_classes.hpp
@@ -499,5 +499,80 @@ private:
 	}
 };
 
+
+//given vectors v and w, forms vector (v,w)
+template<class E1, class E2>
+class vector_concat: public vector_expression<vector_concat<E1,E2>, typename E1::device_type > {
+private:
+	typedef typename device_traits<typename E1::device_type>:: template add<typename E1::value_type> functor_type;
+public:
+	typedef typename common_value_type<E1,E2>::type value_type;
+	typedef value_type const_reference;
+	typedef value_type reference;
+	typedef typename E1::size_type size_type;
+
+	typedef typename E1::const_closure_type lhs_closure_type;
+	typedef typename E2::const_closure_type rhs_closure_type;
+	
+	typedef vector_concat const_closure_type;
+	typedef vector_concat closure_type;
+	typedef unknown_storage storage_type;
+	typedef unknown_storage const_storage_type;
+	typedef blockwise<typename evaluation_tag_restrict_traits<
+		typename E1::evaluation_category::tag,
+		typename E2::evaluation_category::tag
+	>::type> evaluation_category;
+	typedef typename E1::device_type device_type;
+
+	// Construction and destruction
+	explicit vector_concat(
+		lhs_closure_type e1, 
+		rhs_closure_type e2
+	):m_lhs(e1),m_rhs(e2){
+		SIZE_CHECK(e1.size() == e2.size());
+	}
+
+	// Accessors
+	size_type size() const {
+		return m_lhs.size() + m_rhs.size();
+	}
+
+	// Expression accessors
+	lhs_closure_type const& lhs() const {
+		return m_lhs;
+	}
+	rhs_closure_type const& rhs() const {
+		return m_rhs;
+	}
+
+	typename device_traits<device_type>::queue_type& queue()const{
+		return m_lhs.queue();
+	}
+	
+	//computation kernels
+	template<class VecX>
+	void assign_to(vector_expression<VecX, device_type>& x, value_type alpha)const{
+		vector_range<VecX> left(x(),0,m_lhs.size()); 
+		vector_range<VecX> right(x(),m_lhs.size(),x().size()); 
+		assign(left,m_lhs, alpha);
+		assign(right,m_rhs, alpha);
+	}
+	template<class VecX>
+	void plus_assign_to(vector_expression<VecX, device_type>& x, value_type alpha)const{
+		vector_range<VecX> left(x(),0,m_lhs.size()); 
+		vector_range<VecX> right(x(),m_lhs.size(),x().size()); 
+		plus_assign(left,m_lhs, alpha);
+		plus_assign(right,m_rhs, alpha);
+	}
+
+	// Iterator types
+	typedef typename E1::const_iterator const_iterator;
+	typedef const_iterator iterator;
+
+private:
+	lhs_closure_type m_lhs;
+	rhs_closure_type m_rhs;
+};
+
 }
 #endif

--- a/include/remora/detail/vector_expression_classes.hpp
+++ b/include/remora/detail/vector_expression_classes.hpp
@@ -528,9 +528,7 @@ public:
 	explicit vector_concat(
 		lhs_closure_type e1, 
 		rhs_closure_type e2
-	):m_lhs(e1),m_rhs(e2){
-		SIZE_CHECK(e1.size() == e2.size());
-	}
+	):m_lhs(e1),m_rhs(e2){}
 
 	// Accessors
 	size_type size() const {

--- a/include/remora/matrix_expression.hpp
+++ b/include/remora/matrix_expression.hpp
@@ -498,6 +498,119 @@ diagonal_matrix<MatA> to_diagonal(vector_expression<MatA, Device> const& A){
 	return diagonal_matrix<MatA>(A());
 }
 
+
+// Block-Matrix Creation
+
+/// \brief Forms the block matrix (A|B) where B is to the right of A
+template<class MatA, class MatB, class Device>
+matrix_concat<MatA, MatB, true> operator|(
+	matrix_expression<MatA, Device> const& A,
+	matrix_expression<MatB, Device> const& B
+){
+	return matrix_concat<MatA, MatB, true>(A(),B());
+}
+
+/// \brief Forms the block matrix (A|v) where v is a column vector to the right of A
+template<class MatA, class VecV, class Device>
+auto operator|(
+	matrix_expression<MatA, Device> const& A,
+	vector_expression<VecV, Device> const& v
+) -> decltype(A | trans(repeat(v,1))){
+	return A | trans(repeat(v,1));
+}
+
+/// \brief Forms the block matrix (v|A) where v is a column vector to the left of A
+template<class MatA, class VecV, class Device>
+auto operator|(
+	vector_expression<VecV, Device> const& v,
+	matrix_expression<MatA, Device> const& A
+) -> decltype(trans(repeat(v,1)) | A){
+	return trans(repeat(v,1)) | A;
+}
+
+/// \brief Forms the block matrix (A|t)
+///
+/// The scalar t is interpreted as column vector
+template<class MatA, class T, class Device>
+typename boost::enable_if<
+	std::is_convertible<T, typename MatA::value_type>, 
+	matrix_concat<MatA, scalar_matrix<T, Device>, true > 
+>::type operator|(
+	matrix_expression<MatA, Device> const& A,
+	T const& t
+){
+	return A | repeat(t,A().size1(), 1);
+}
+
+/// \brief Forms the block matrix (t|A)
+///
+/// The scalar t is interpreted as column vector
+template<class MatA, class T, class Device>
+typename boost::enable_if<
+	std::is_convertible<T, typename MatA::value_type>, 
+	matrix_concat<scalar_matrix<T, Device>, MatA, true > 
+>::type operator|(
+	T const& t,
+	matrix_expression<MatA, Device> const& A
+){
+	return repeat(t,A().size1(), 1) | A;
+}
+
+///\brief Forms the block matrix A&B where A is on top of B
+template<class MatA, class MatB, class Device>
+matrix_concat<MatA, MatB, false> operator&(
+	matrix_expression<MatA, Device> const& A,
+	matrix_expression<MatB, Device> const& B
+){
+	return matrix_concat<MatA, MatB, false>(A(),B());
+}
+
+/// \brief Forms the block matrix (A & v) where v is a row vector on the bottom of A
+template<class MatA, class VecV, class Device>
+auto operator&(
+	matrix_expression<MatA, Device> const& A,
+	vector_expression<VecV, Device> const& v
+) -> decltype(A & repeat(v,1)){
+	return A & repeat(v,1);
+}
+
+/// \brief Forms the block matrix (A & v) where v is a row vector on the top of A
+template<class MatA, class VecV, class Device>
+auto operator&(
+	vector_expression<VecV, Device> const& v,
+	matrix_expression<MatA, Device> const& A
+) -> decltype(repeat(v,1) & A){
+	return repeat(v,1) & A;
+}
+
+/// \brief Forms the block matrix (A & t)
+///
+/// The scalar t is interpreted as row vector
+template<class MatA, class T, class Device>
+typename boost::enable_if<
+	std::is_convertible<T, typename MatA::value_type>, 
+	matrix_concat<MatA, scalar_matrix<T, Device>, false > 
+>::type operator&(
+	matrix_expression<MatA, Device> const& A,
+	T const& t
+){
+	return A & repeat(t, 1, A().size2());
+}
+
+/// \brief Forms the block matrix (t & A)
+///
+/// The scalar t is interpreted as row vector
+template<class MatA, class T, class Device>
+typename boost::enable_if<
+	std::is_convertible<T, typename MatA::value_type>, 
+	matrix_concat<scalar_matrix<T, Device>, MatA, false > 
+>::type operator&(
+	T const& t,
+	matrix_expression<MatA, Device> const& A
+){
+	return repeat(t,1, A().size2()) & A;
+}
+
 }
 
 #endif

--- a/include/remora/vector_expression.hpp
+++ b/include/remora/vector_expression.hpp
@@ -357,6 +357,49 @@ inner_prod(
 	return result;
 }
 
+
+// Vector Concatenation
+
+
+///\brief Concatenates two vectors
+///
+/// Given two vectors v and w, forms the vector (v,w). 
+template<class VecV1, class VecV2, class Device>
+vector_concat<VecV1,VecV2> operator|(
+	vector_expression<VecV1, Device> const& v1,
+	vector_expression<VecV2, Device> const& v2
+){
+	return vector_concat<VecV1,VecV2>(v1(),v2());
+}
+
+///\brief Concatenates a vector with a scalar
+///
+/// Given a vector v and a scalar t, forms the vector (v,t)
+template<class VecV, class T, class Device>
+typename boost::enable_if<
+	std::is_convertible<T, typename VecV::value_type>, 
+	vector_concat<VecV, scalar_vector<T, Device> >
+>::type operator| (
+	vector_expression<VecV, Device> const& v,
+	T t
+){
+	return v | scalar_vector<T, Device>(1,t);
+}
+
+///\brief Concatenates a vector with a scalar
+///
+/// Given a vector v and a scalar t, forms the vector (v,t)
+template<class T, class VecV, class Device>
+typename boost::enable_if<
+	std::is_convertible<T, typename VecV::value_type>,
+	vector_concat<scalar_vector<T, Device>,VecV >
+>::type operator| (
+	T t,
+	vector_expression<VecV, Device> const& v
+){
+	return scalar_vector<T, Device>(1,t) | v;
+}
+
 }
 
 #endif


### PR DESCRIPTION
I have added operators | and & to be able to create block matrices easier. e.g. adding a columns of all ones at the end is as easy as (X|1).

and a matrix
A B
C D

is created by (A |B) & (C | D)